### PR TITLE
Change PDO::PARAM_NULL to resolve to SQLT_CHR

### DIFF
--- a/src/yajra/Pdo/Oci8/Statement.php
+++ b/src/yajra/Pdo/Oci8/Statement.php
@@ -226,7 +226,7 @@ class Statement
                 break;
 
             case \PDO::PARAM_NULL:
-                $oci_type =  SQLT_INT;
+                $oci_type =  SQLT_CHR;
                 break;
 
             case \PDO::PARAM_INT:


### PR DESCRIPTION
When inserting NULLs for columns on & off in the definition below the value entered was a string of "0"

``` php
schema::create('on_off_messages', function (Blueprint $table) {
    $table->increments('id', 'device_status_bits_pk');
    $table->string('on', 64)->nullable();
    $table->string('off', 64)->nullable();
});
```

This change allows NULLs to be entered. It appears that NULLs are still entered into integer fields correctly too, though I would advise this is tested in your environment too!
