### PR TITLE
Bug fix for command 'insert into table(field)' when using DB::insert (Un...

### DIFF
--- a/src/yajra/Pdo/Oci8.php
+++ b/src/yajra/Pdo/Oci8.php
@@ -106,7 +106,7 @@ class Oci8
 
         // check if statement is insert function
         if (strpos(strtolower($statement), 'insert into')!==false) {
-            preg_match('/insert into (.*?) /', strtolower($statement), $matches);
+            preg_match('/insert into\s+([^\s\(]*)?/', strtolower($statement), $matches);
             // store insert into table name
             $this->_table = $matches[1];
         }


### PR DESCRIPTION
When trying to execute the following command:

DB::insert(DB::raw('INSERT INTO table(field)
            select field from table2'
        ));

It was giving this error: Undefined offset 1
