### PR TITLE
Check existence of charset key in options in Oci8 constuctor

### DIFF
--- a/src/yajra/Pdo/Oci8.php
+++ b/src/yajra/Pdo/Oci8.php
@@ -64,11 +64,18 @@ class Oci8
      */
     public function __construct($dsn, $username, $password, array $options = array())
     {
+        // Get the character set
+        $charset = null;
+        if (array_key_exists("charset", $options))
+        {
+            $charset = $options["charset"];
+        }
+
         //Attempt a connection
         if (isset($options[\PDO::ATTR_PERSISTENT]) && $options[\PDO::ATTR_PERSISTENT]) {
-            $this->_dbh = @oci_pconnect($username, $password, $dsn, $options['charset']);
+            $this->_dbh = @oci_pconnect($username, $password, $dsn, $charset);
         } else {
-            $this->_dbh = @oci_connect($username, $password, $dsn, $options['charset']);
+            $this->_dbh = @oci_connect($username, $password, $dsn, $charset);
         }
 
         //Check if connection was successful


### PR DESCRIPTION
The constructor makes use of the charkey value in the options array. When
using an error setting that turns notices into errors and when you
convert all errors into exceptions, this section of code will throw
an exception when the options array doesn't contain the charkey key.

This patch checks for the existence of the charset key and sets values
appropriately so that PHP doesn't throw an exception.

You may not need it since your DSN parsing comes from Laravel OCI8 - Connector, but I figured I would submit anyway.
