### PR TITLE
Add support for more fetch modes.

### DIFF
--- a/src/yajra/Pdo/Oci8.php
+++ b/src/yajra/Pdo/Oci8.php
@@ -255,7 +255,6 @@ class Oci8
      * @param mixed|null $modeArg Column number, class name or object.
      * @param array|null $ctorArgs Constructor arguments.
      * @return Statement
-     * @todo Implement support for $fetchType, $typeArg, and $ctorArgs.
      */
     public function query($statement,
                           $fetchMode = null,
@@ -264,6 +263,9 @@ class Oci8
     {
         $stmt = $this->prepare($statement);
         $stmt->execute();
+        if ($fetchMode) {
+            $stmt->setFetchMode($fetchMode, $modeArg, $ctorArgs);
+        }
 
         return $stmt;
     }

--- a/src/yajra/Pdo/Oci8/Statement.php
+++ b/src/yajra/Pdo/Oci8/Statement.php
@@ -67,6 +67,41 @@ class Statement
     protected $_options = array();
 
     /**
+     * Fetch mode selected via setFetchMode()
+     *
+     * @var int
+     */
+    protected $_fetchMode = \PDO::ATTR_DEFAULT_FETCH_MODE;
+
+    /**
+     * Column number for PDO::FETCH_COLUMN fetch mode
+     *
+     * @var int
+     */
+    protected $_fetchColno = 0;
+
+    /**
+     * Class name for PDO::FETCH_CLASS fetch mode
+     *
+     * @var string
+     */
+    protected $_fetchClassName = '\stdClass';
+
+    /**
+     * Constructor arguments for PDO::FETCH_CLASS
+     *
+     * @var array
+     */
+    protected $_fetchCtorargs = array();
+
+    /**
+     * Object reference for PDO::FETCH_into fetch mode
+     *
+     * @var object
+     */
+    protected $_fetchIntoObject = null;
+
+    /**
      * Constructor
      *
      * @param resource $sth Statement handle created with oci_parse()
@@ -131,7 +166,7 @@ class Statement
     /**
      * Fetches the next row from a result set
      *
-     * @param int|null $fetchStyle Controls how the next row will be returned to
+     * @param int|null $fetchMode Controls how the next row will be returned to
      *   the caller. This value must be one of the PDO::FETCH_* constants,
      *   defaulting to value of PDO::ATTR_DEFAULT_FETCH_MODE (which defaults to
      *   PDO::FETCH_BOTH).
@@ -143,22 +178,28 @@ class Statement
      *   to PDO::CURSOR_SCROLL when you prepare the SQL statement with
      *   PDO::prepare.
      * @param int $cursorOffset [optional]
-     * @return mixed
+     * @return mixed The return value of this function on success depends on the
+     *   fetch type. In all cases, FALSE is returned on failure.
      * @todo Implement cursorOrientation and cursorOffset
-     * @todo Fix PDO::FETCH_CLASS with specified class name and constructor
-     *       arguments
-     * @todo Implement PDO::FETCH_OBJECT
      */
-    public function fetch($fetchStyle = \PDO::FETCH_BOTH,
+    public function fetch($fetchMode = null,
                           $cursorOrientation = \PDO::FETCH_ORI_NEXT,
                           $cursorOffset = 0)
     {
+        // If not fetchMode was specified, used the default value of or the mode
+        // set by the last call to setFetchMode()
+        if ($fetchMode === null) {
+            $fetchMode = $this->_fetchMode;
+        }
+
         // Convert array keys (or object properties) to lowercase
         $toLowercase = ($this->getAttribute(\PDO::ATTR_CASE) == \PDO::CASE_LOWER);
-        switch($fetchStyle)
+
+        // Determine the fetch mode
+        switch($fetchMode)
         {
             case \PDO::FETCH_BOTH:
-                $rs = oci_fetch_array($this->_sth); // add OCI_BOTH?
+                $rs = oci_fetch_array($this->_sth); // Fetches both; nice!
                 if($rs === false) {
                     return false;
                 }
@@ -190,15 +231,10 @@ class Statement
                 return $rs;
 
             case \PDO::FETCH_NUM:
-                return oci_fetch_row($this->_sth);
-
-            case \PDO::FETCH_CLASS:
-                $rs = oci_fetch_assoc($this->_sth);
+                $rs = oci_fetch_row($this->_sth);
                 if($rs === false) {
                     return false;
                 }
-                if($toLowercase) $rs = array_change_key_case($rs);
-
                 if ($this->returnLobs && is_array($rs)) {
                     foreach ($rs as $field => $value) {
                         if (is_object($value) ) {
@@ -207,8 +243,69 @@ class Statement
                     }
                 }
 
-                return (object) $rs;
+                return $rs;
+
+            case \PDO::FETCH_COLUMN:
+                $rs = oci_fetch_row($this->_sth);
+                if (array_key_exists($this->_fetchColno, $rs)) {
+                    $value = $rs[$this->_fetchColno];
+                    if (is_object($value)) {
+                        return $value->load();
+                    } else {
+                        return $value;
+                    }
+                } else {
+                    return false;
+                }
+                break;
+
+            case \PDO::FETCH_OBJ:
+            case \PDO::FETCH_INTO:
+            case \PDO::FETCH_CLASS:
+            case \PDO::FETCH_CLASS | \PDO::FETCH_PROPS_LATE:
+                $rs = oci_fetch_assoc($this->_sth);
+                if($rs === false) {
+                    return false;
+                }
+                if($toLowercase) $rs = array_change_key_case($rs);
+
+                if ($fetchMode === \PDO::FETCH_INTO) {
+                    if (is_object($this->_fetchIntoObject)) {
+                        $object = $this->_fetchIntoObject;
+                    } else {
+                        // Object to set into has not been set
+                        return false;
+                    }
+                } else {
+                    if ($fetchMode === \PDO::FETCH_OBJ) {
+                        $className = '\stdClass';
+                        $ctorargs = array();
+                    } else {
+                        $className = $this->_fetchClassName;
+                        $ctorargs = $this->_fetchCtorargs;
+                    }
+
+                    if ($ctorargs) {
+                        $reflectionClass = new \ReflectionClass($className);
+                        $object = $reflectionClass->newInstanceArgs($ctorargs);
+                    } else {
+                        $object = new $className();
+                    }
+                }
+
+                foreach($rs as $field => $value)
+                {
+                    if ($this->returnLobs && is_object($value)) {
+                        $object->$field = $value->load();
+                    } else {
+                        $object->$field = $value;
+                    }
+                }
+
+                return $object;
         }
+
+        return false;
     }
 
     /**
@@ -349,32 +446,34 @@ class Statement
      * @param int $colNumber 0-indexed number of the column you wish to retrieve
      *   from the row. If no value is supplied, it fetches the first column.
      * @return string Returns a single column in the next row of a result set.
-     * @todo Implement colNumber
      */
-    public function fetchColumn($colNumber = 0)
+    public function fetchColumn($colNumber = null)
     {
-        return reset($this->fetch());
+        $this->setFetchMode(\PDO::FETCH_COLUMN, $colNumber);
+        return $this->fetch();
     }
 
     /**
      * Returns an array containing all of the result set rows
      *
-     * @param int $fetchStyle Controls the contents of the returned array as
+     * @param int $fetchMode Controls the contents of the returned array as
      *   documented in PDOStatement::fetch.
      * @param mixed $fetchArgument This argument has a different meaning
-     *   depending on the value of the fetchStyle parameter.
+     *   depending on the value of the fetchMode parameter.
      * @param array $ctorArgs [optional] Arguments of custom class constructor
      *   when the fetch_style parameter is PDO::FETCH_CLASS.
      * @return array Array containing all of the remaining rows in the result
      *   set. The array represents each row as either an array of column values
      *   or an object with properties corresponding to each column name.
      */
-    public function fetchAll($fetchStyle = \PDO::FETCH_BOTH,
+    public function fetchAll($fetchMode = \PDO::FETCH_BOTH,
                              $fetchArgument = null,
-                             $ctorArgs = null)
+                             $ctorArgs = array())
     {
+        $this->setFetchMode($fetchMode, $fetchArgument, $ctorArgs);
+
         $results = array();
-        while($row = $this->fetch($fetchStyle, $fetchArgument, $ctorArgs))
+        while($row = $this->fetch())
         {
             $results[] = $row;
         }
@@ -387,12 +486,11 @@ class Statement
      * @param string $className
      * @param array $ctorArgs
      * @return mixed
-     * @todo Implement className and ctorArgs; easiest implementation will be
-     *       by implementing in fetch() and calling it with proper parameters
      */
-    public function fetchObject($className = null, $ctorArgs = null)
+    public function fetchObject($className = null, $ctorArgs = array())
     {
-        return (object)$this->fetch();
+        $this->setFetchMode(\PDO::FETCH_CLASS, $className, $ctorArgs);
+        return $this->fetch();
     }
 
     /**
@@ -521,13 +619,60 @@ class Statement
      * @param array|null $ctorArgs Constructor arguments.
      * @throws \Exception
      * @return bool TRUE on success or FALSE on failure.
-     * @todo Implement method
      */
     public function setFetchMode($fetchMode,
                                  $modeArg = null,
                                  array $ctorArgs = array())
     {
-        throw new \Exception("seteFetchMode has not been implemented");
+        // See which fetch mode we have
+        switch($fetchMode)
+        {
+            case \PDO::FETCH_ASSOC:
+            case \PDO::FETCH_NUM:
+            case \PDO::FETCH_BOTH:
+            case \PDO::FETCH_OBJ:
+                $this->_fetchMode = $fetchMode;
+                $this->_fetchColno = 0;
+                $this->_fetchClassName = '\stdClass';
+                $this->_fetchCtorargs = array();
+                $this->_fetchIntoObject = null;
+                break;
+            case \PDO::FETCH_CLASS:
+            case \PDO::FETCH_CLASS | \PDO::FETCH_PROPS_LATE:
+                $this->_fetchMode = $fetchMode;
+                $this->_fetchColno = 0;
+                $this->_fetchClassName = '\stdClass';
+                if ($modeArg) {
+                    $this->_fetchClassName = $modeArg;
+                }
+                $this->_fetchCtorargs = $ctorArgs;
+                $this->_fetchIntoObject = null;
+                break;
+            case \PDO::FETCH_INTO:
+                if (! is_object($modeArg)) {
+                    throw new \Exception(
+                        '$modeArg must be instance of an object');
+                }
+                $this->_fetchMode = $fetchMode;
+                $this->_fetchColno = 0;
+                $this->_fetchClassName = '\stdClass';
+                $this->_fetchCtorargs = array();
+                $this->_fetchIntoObject = $modeArg;
+                break;
+            case \PDO::FETCH_COLUMN:
+                $this->_fetchMode = $fetchMode;
+                $this->_fetchColno = (int) $modeArg;
+                $this->_fetchClassName = '\stdClass';
+                $this->_fetchCtorargs = array();
+                $this->_fetchIntoObject = null;
+                break;
+            default:
+                throw new \Exception("Requested fetch mode is not supported " .
+                    "by this implementation");
+                break;
+        }
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
This patch adds support for the following fetch modes:

  PDO::FETCH_COLUMN
  PDO::FETCH_OBJ
  PDO::FETCH_INTO
  PDO::FETCH_CLASS
  PDO::FETCH_CLASS | PDO::FETCH_PROPS_LATE

In order to add these new fetch modes, Statement::setFetchMode() was
implemented, and all other functions that had arguments for fetch mode
have now been implemented.

This patch also fixes a bug in Statement::fetchColumn where it would only
return the first column, even if colNumber was set.
