### PR TITLE
PHP 7 fix for bindValue

### DIFF
--- a/src/Pdo/Oci8/Statement.php
+++ b/src/Pdo/Oci8/Statement.php
@@ -446,7 +446,7 @@ class Statement extends PDOStatement
             return $this->bindArray($parameter, $variable, $maxLength, $maxLength, $ociType);
         }
 
-        $this->bindings[] = $variable;
+        $this->bindings[] = &$variable;
 
         return oci_bind_by_name($this->sth, $parameter, $variable, $maxLength, $ociType);
     }


### PR DESCRIPTION
bindValue breaks in PHP 7, but the fix is simple.
Here's a minimal code sample that works in PHP 5, but not 7:

```php
$conn = new Oci8('**redacted**', '**also redacted**', '**not for you to know**');
$statement = $conn->prepare("SELECT * FROM USERS WHERE ID = :id");
$userId = 1;
$statement->bindValue(':id', $userId);
$success = $statement->execute();
$results = $statement->fetchAll();
print_r($results);
```

In 7, it blows up with a "ORA-01722: invalid number", because by the time the oci_execute function is called, the bound $variable has disappeared.
It seems that PHP 7 is smarter about disposing of variables it deems no longer necessary.
So the *copy* of $variable that's created when bindValue is called disappears once bindValue exits.

My proposed fix in this patch is to simply add the $variable to $this->bindings by *reference*. That way, PHP will know that the variable itself needs to persist after bindValue exits.