### PR TITLE
Clean DSN - check charset option in connection string (         //Fin…

### DIFF
--- a/src/Pdo/Oci8/Statement.php
+++ b/src/Pdo/Oci8/Statement.php
@@ -779,11 +779,17 @@ class Statement extends PDOStatement
      *
      * @throws Oci8Exception
      * @return bool TRUE on success or FALSE on failure.
-     * @todo Implement method
      */
     public function closeCursor()
     {
-        throw new Oci8Exception("setFetchMode has not been implemented");
+        if(!$this->sth) return true;
+         try {
+              \oci_free_statement($this->sth);
+        } catch (\Exception $e) {
+            throw new Oci8Exception($e->getMessage());
+        }
+         $this->sth = null;
+        return true;
     }
 
     /**


### PR DESCRIPTION
1. Clean PDO Style DSN and check charset option in connection string 
Find the charset in connection String, 
example:
`oci:dbname=192.168.1.1/orcl;charset=CL8MSWIN1251`

2. Implement closeCursor statement method.