### PR TITLE
Parse DSN - check charset option in connection string and clean "PDO style"

### DIFF
--- a/src/Pdo/Oci8/Statement.php
+++ b/src/Pdo/Oci8/Statement.php
@@ -779,17 +779,11 @@ class Statement extends PDOStatement
      *
      * @throws Oci8Exception
      * @return bool TRUE on success or FALSE on failure.
+     * @todo Implement method
      */
     public function closeCursor()
     {
-        if(!$this->sth) return true;
-         try {
-              \oci_free_statement($this->sth);
-        } catch (\Exception $e) {
-            throw new Oci8Exception($e->getMessage());
-        }
-         $this->sth = null;
-        return true;
+        throw new Oci8Exception("closeCursor has not been implemented");
     }
 
     /**

--- a/src/Pdo/Oci8/Statement.php
+++ b/src/Pdo/Oci8/Statement.php
@@ -779,11 +779,17 @@ class Statement extends PDOStatement
      *
      * @throws Oci8Exception
      * @return bool TRUE on success or FALSE on failure.
-     * @todo Implement method
      */
     public function closeCursor()
     {
-        throw new Oci8Exception("setFetchMode has not been implemented");
+        if(!$this->sth) return true;
+         try {
+              \oci_free_statement($this->sth);
+        } catch (\Exception $e) {
+            throw new Oci8Exception($e->getMessage());
+        }
+         $this->sth = null;
+        return true;
     }
 
     /**


### PR DESCRIPTION
Parse $dsn = "oci:dbname=10.20.7.1:1521/orcl;charset=AL32UTF8"
to
$dsn ="10.20.7.1:1521/orcl"  
and put charset value  (  AL32UTF8) in connect method