### PR TITLE
function fetchAll() bug fix

### DIFF
--- a/src/Pdo/Oci8/Statement.php
+++ b/src/Pdo/Oci8/Statement.php
@@ -554,7 +554,9 @@ class Statement extends PDOStatement
 
         $this->results = array();
         while ($row = $this->fetch()) {
-            if (is_array($row)) reset($row);
+            if (is_array($row)) {
+                $row = reset($row);
+            }
             if (is_resource($row)) {
                 $stmt = new Statement($row, $this->connection, $this->options);
                 $stmt->execute();

--- a/src/Pdo/Oci8/Statement.php
+++ b/src/Pdo/Oci8/Statement.php
@@ -554,8 +554,9 @@ class Statement extends PDOStatement
 
         $this->results = array();
         while ($row = $this->fetch()) {
-            if (is_resource(reset($row))) {
-                $stmt = new Statement(reset($row), $this->connection, $this->options);
+            if (is_array($row)) reset($row);
+            if (is_resource($row)) {
+                $stmt = new Statement($row, $this->connection, $this->options);
                 $stmt->execute();
                 $stmt->setFetchMode($fetchMode, $fetchArgument, $ctorArgs);
                 while ($rs = $stmt->fetch()) {


### PR DESCRIPTION
if $this->fetch() return not array
then line with reset($row) throw Database Exception – yii\db\Exception in Yii2
reset() expects parameter 1 to be array, string given
Fix this bug