### PR TITLE
Fix non-FETCH_COLUMN queries

### DIFF
--- a/src/Pdo/Oci8/Statement.php
+++ b/src/Pdo/Oci8/Statement.php
@@ -554,11 +554,8 @@ class Statement extends PDOStatement
 
         $this->results = array();
         while ($row = $this->fetch()) {
-            if (is_array($row)) {
-                $row = reset($row);
-            }
-            if (is_resource($row)) {
-                $stmt = new Statement($row, $this->connection, $this->options);
+            if (is_array($row) && is_resource(reset($row))) {
+                $stmt = new Statement(reset($row), $this->connection, $this->options);
                 $stmt->execute();
                 $stmt->setFetchMode($fetchMode, $fetchArgument, $ctorArgs);
                 while ($rs = $stmt->fetch()) {


### PR DESCRIPTION
The pull request for v1.0.3 fixed FETCH_COLUMN queries, but broke every other query type.
```php
$row = reset($row);
```
replaces the whole "$row" array with its first element, throwing away the rest of the original $row data.
This patch replaces that original fix with a simpler one. Now FETCH_COLUMN *and* other FETCH_ modes all work.