### PR TITLE
3rd argument in Statement::setFetchMode(), $ctorArgs, should allow null

### DIFF
--- a/src/Pdo/Oci8/Statement.php
+++ b/src/Pdo/Oci8/Statement.php
@@ -720,7 +720,7 @@ class Statement extends PDOStatement
      * @throws Oci8Exception
      * @return bool TRUE on success or FALSE on failure.
      */
-    public function setFetchMode($fetchMode, $modeArg = null, array $ctorArgs = array())
+    public function setFetchMode($fetchMode, $modeArg = null, $ctorArgs = array())
     {
         // See which fetch mode we have
         switch ($fetchMode) {


### PR DESCRIPTION
This fixes the the following error when used with Laravel v5.2.42.

Argument 3 passed to Yajra\Pdo\Oci8\Statement::setFetchMode() must be of the type array, null given.