### PR TITLE
Fixes for Array bindings

### DIFF
--- a/src/Pdo/Oci8/Statement.php
+++ b/src/Pdo/Oci8/Statement.php
@@ -455,7 +455,7 @@ class Statement extends PDOStatement
         }
 
         if (is_array($variable)) {
-            return $this->bindArray($parameter, $variable, $maxLength, $maxLength, $ociType);
+            return $this->bindArray($parameter, $variable, count($variable), $maxLength, $ociType);
         }
 
         $this->bindings[] = &$variable;

--- a/src/Pdo/Oci8/Statement.php
+++ b/src/Pdo/Oci8/Statement.php
@@ -191,6 +191,8 @@ class Statement extends PDOStatement
         foreach ($this->bindings as $binding) {
             if (is_object($binding)) {
                 $bindings[] = get_class($binding);
+            } elseif (is_array($binding)) {
+                $bindings[] = 'Array';
             } else {
                 $bindings[] = (string) $binding;
             }


### PR DESCRIPTION
<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you read the [Contributing Guidelines](https://github.com/yajra/pdo-via-oci8/blob/master/.github/CONTRIBUTING.md)?

If you answered yes, thanks for the PR and we'll get to it ASAP! :)

-->
Function `displayBindings` was showing an Array to String conversion error if a binding was an array, so I added logic to catch such bindings.

The call to `bindArray` was also throwing an error as `$maxLength` defaulted to -1, but the call to `oci_bind_array_by_name` within `bindArray` needs an array length parameter greater than zero.