### PR TITLE
Modify Oci8Exception object to add access to Oracle debugging detail

### DIFF
--- a/src/Pdo/Oci8/Exceptions/Oci8Exception.php
+++ b/src/Pdo/Oci8/Exceptions/Oci8Exception.php
@@ -6,4 +6,69 @@ use PDOException;
 
 class Oci8Exception extends PDOException
 {
+
+    protected $oci_err;
+
+    /***
+     * Macig functions to create and output Exception class
+     */
+    public function __construct (string $message ="", int $code =0, PDOException $e =null, $oci_err =[]) {
+
+        parent::__construct ($message, $code, $e);
+
+        if ( !empty($oci_err) ) {
+            $this->oci_err = $oci_err;
+        } else {
+            $this->oci_err['message']  = $message;
+            $this->oci_err['code']     = '00000';
+            $this->oci_err['sqltext']  = '';
+            $this->oci_err['bindings'] = '[]';
+        }
+
+    }
+
+    public function __toString() {
+        return $this->getOciAllErrorDetail();
+    }
+
+
+    /***
+     * Getters for variouis types of information from the returned OCI error array
+     */
+    public function getOciUserFriendlyMsg() {
+        $msg_arr = explode ("\n", $this->oci_err['message']);
+        return preg_replace ('/ORA-[0-9]{5}: /', '', $msg_arr[0]);
+    }
+
+    public function getOciErrorCode() {
+        return $this->oci_err['code'];
+    }
+
+    public function getOriginalSql() {
+        return $this->oci_err['sqltext'];
+    }
+
+    public function getOciErrorStack() {
+        return $this->oci_err['message'];
+    }
+
+    public function getOciBindings() {
+        return $this->oci_err['bindings'];
+    }
+
+    public function getOciAllErrorDetail() {
+        return
+            'Error Code  : ' . $this->oci_err['code']     . PHP_EOL .
+            'Position    : ' . $this->oci_err['offset']   . PHP_EOL .
+            'Statement   : ' . $this->oci_err['sqltext']  . PHP_EOL .
+            'Bindings    : ' . $this->oci_err['bindings'] . PHP_EOL .
+            'Error Stack : ' . PHP_EOL . $this->oci_err['message'];
+    }
+
+    public function getHtmlErrorStack() {
+        $msg = $this->oci_err['message'];
+        $msg = str_replace (chr(10), '<br />', $msg);
+        return '<code>' . $msg . '</code>';
+    }
+
 }

--- a/src/Pdo/Oci8/Statement.php
+++ b/src/Pdo/Oci8/Statement.php
@@ -166,15 +166,8 @@ class Statement extends PDOStatement
 
         if ($result != true) {
             $e = oci_error($this->sth);
-
-            $message = '';
-            $message = $message . 'Error Code    : ' . $e['code'] . PHP_EOL;
-            $message = $message . 'Error Message : ' . $e['message'] . PHP_EOL;
-            $message = $message . 'Position      : ' . $e['offset'] . PHP_EOL;
-            $message = $message . 'Statement     : ' . $e['sqltext'] . PHP_EOL;
-            $message = $message . 'Bindings      : [' . $this->displayBindings() . ']' . PHP_EOL;
-
-            throw new Oci8Exception($message, $e['code']);
+            $e['bindings'] = $this->displayBindings();
+            throw new Oci8Exception ($e['message'], $e['code'], null, $e);
         }
 
         return $result;
@@ -198,7 +191,7 @@ class Statement extends PDOStatement
             }
         }
 
-        return implode(',', $bindings);
+        return '[' . implode(',', $bindings) . ']';
     }
 
     /**


### PR DESCRIPTION
As per [request for a Pull Request](https://github.com/yajra/pdo-via-oci8/issues/50), I'm now submitting changes that I've applied.

The objective is to build better Oracle debugging support into the Oci8Exception class, so that (for example) user-facing error-messages are easier to extract.

These changes are slightly different than the original suggestions documented in the original thread.  Rather than allow Exception-throwing code in `Statement.php` to build a lengthy message string to pass to the Exception object, I've decided to simply pass the PDO exception-array to the Exception class instead, so that the Exception class itself can do the legwork.  This reduces the overhead of constructing and de-constructing the message string to find the necessary debug info.