### PR TITLE
Revert "Changed to LONG type because number type can not be registered normally"

### DIFF
--- a/src/Pdo/Oci8/Statement.php
+++ b/src/Pdo/Oci8/Statement.php
@@ -426,7 +426,7 @@ class Statement extends PDOStatement
                 break;
 
             case PDO::PARAM_INT:
-                $ociType = SQLT_LNG;
+                $ociType = SQLT_INT;
                 break;
 
             case PDO::PARAM_STR:


### PR DESCRIPTION
Reverts yajra/pdo-via-oci8#42
Fix https://github.com/yajra/laravel-oci8/issues/386.
Fix failing unit tests `Failed asserting that '40' is identical to 40.`