### PR TITLE
For large param for blob and clob.

### DIFF
--- a/src/Pdo/Oci8/Statement.php
+++ b/src/Pdo/Oci8/Statement.php
@@ -439,6 +439,7 @@ class Statement extends PDOStatement
                 $this->blobBindings[$parameter] = $variable;
 
                 $variable = $this->connection->getNewDescriptor();
+                $variable->writeTemporary($this->blobBindings[$parameter], OCI_TEMP_BLOB);
 
                 $this->blobObjects[$parameter] = &$variable;
                 break;
@@ -466,6 +467,7 @@ class Statement extends PDOStatement
                 $this->blobBindings[$parameter] = $variable;
 
                 $variable = $this->connection->getNewDescriptor();
+                $variable->writeTemporary($this->blobBindings[$parameter], OCI_TEMP_CLOB);
 
                 $this->blobObjects[$parameter] = &$variable;
                 break;


### PR DESCRIPTION
Sometime it's show OCI-Lob::save(): OCI_INVALID_HANDLE" if now writeTemporary.