### PR TITLE
Bind parameters should use named parameters indexed from 1.

### DIFF
--- a/src/Pdo/Oci8.php
+++ b/src/Pdo/Oci8.php
@@ -102,7 +102,7 @@ class Oci8 extends PDO
         // Skip replacing ? with a pseudo named parameter on alter/create table command
         if ($this->isNamedParameterable($statement)) {
             // Replace ? with a pseudo named parameter
-            $parameter    = 0;
+            $parameter    = 1;
             $statement = preg_replace_callback('/(?:\'[^\']*\')(*SKIP)(*F)|\?/', function () use (&$parameter) {
                 return ':p' . $parameter++;
             }, $statement);


### PR DESCRIPTION
Named parameters should be indexed from 1 since [PDOStatement::bindValue](http://php.net/manual/en/pdostatement.bindvalue.php) use _1-indexed position of the parameter_.