### PR TITLE
Fix fetch mode usage.

### DIFF
--- a/src/Pdo/Oci8/Statement.php
+++ b/src/Pdo/Oci8/Statement.php
@@ -48,7 +48,7 @@ class Statement extends PDOStatement
      *
      * @var int
      */
-    private $fetchMode = PDO::ATTR_DEFAULT_FETCH_MODE;
+    private $fetchMode = PDO::FETCH_BOTH;
 
     /**
      * Column number for PDO::FETCH_COLUMN fetch mode.
@@ -125,6 +125,11 @@ class Statement extends PDOStatement
         $this->sth        = $sth;
         $this->connection = $connection;
         $this->options    = $options;
+
+        $fetchMode = $connection->getAttribute(PDO::ATTR_DEFAULT_FETCH_MODE);
+        if ($fetchMode) {
+            $this->setFetchMode($fetchMode);
+        }
     }
 
     /**


### PR DESCRIPTION
Use `PDO::FETCH_BOTH` as default. `PDO::ATTR_DEFAULT_FETCH_MODE` is an invalid fetch mode.

This commit fixes `$stmt->fetch();` without fetch style, that returns `false` (at least in php 7.1). `PDO::ATTR_DEFAULT_FETCH_MODE` is invalid for fetch. (see http://php.net/manual/en/pdostatement.fetch.php)

Now, `fetch` without fetch style uses default fetch for connection or `PDO::FETCH_BOTH` if it is not defined.

<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you read the [Contributing Guidelines](https://github.com/yajra/pdo-via-oci8/blob/master/.github/CONTRIBUTING.md)?

If you answered yes, thanks for the PR and we'll get to it ASAP! :)

-->
