### PR TITLE
Added support for oci session_mode (wallet)

### DIFF
--- a/src/Pdo/Oci8.php
+++ b/src/Pdo/Oci8.php
@@ -447,7 +447,7 @@ class Oci8 extends PDO
      */
     private function connect($dsn, $username, $password, array $options, $charset)
     {
-        $sessionMode = array_get($options, 'session_mode');
+        $sessionMode = array_key_exists('session_mode', $options) ? $options['session_mode'] : null;
 
         if (array_key_exists(PDO::ATTR_PERSISTENT, $options) && $options[PDO::ATTR_PERSISTENT]) {
             $this->dbh = @oci_pconnect($username, $password, $dsn, $charset, $sessionMode);

--- a/src/Pdo/Oci8.php
+++ b/src/Pdo/Oci8.php
@@ -447,10 +447,12 @@ class Oci8 extends PDO
      */
     private function connect($dsn, $username, $password, array $options, $charset)
     {
+        $sessionMode = array_get($options, 'session_mode');
+
         if (array_key_exists(PDO::ATTR_PERSISTENT, $options) && $options[PDO::ATTR_PERSISTENT]) {
-            $this->dbh = @oci_pconnect($username, $password, $dsn, $charset);
+            $this->dbh = @oci_pconnect($username, $password, $dsn, $charset, $sessionMode);
         } else {
-            $this->dbh = @oci_connect($username, $password, $dsn, $charset);
+            $this->dbh = @oci_connect($username, $password, $dsn, $charset, $sessionMode);
         }
 
         if (! $this->dbh) {


### PR DESCRIPTION
`oci_[p]connect()` has another parameter that allows you to specify the session mode. 
When you want to use a wallet you'll have to set this to `OCI_CRED_EXT`.

This change allows you to add a '`session_mode'`-entry in the `$options` to control this parameter.