### PR TITLE
Fix PDO::ATTR_PERSISTENT when is set to false

### DIFF
--- a/src/Pdo/Oci8.php
+++ b/src/Pdo/Oci8.php
@@ -467,7 +467,7 @@ class Oci8 extends PDO
     {
         $sessionMode = array_key_exists('session_mode', $options) ? $options['session_mode'] : null;
 
-        if (array_key_exists(PDO::ATTR_PERSISTENT, $options)) {
+        if (array_key_exists(PDO::ATTR_PERSISTENT, $options) && $options[PDO::ATTR_PERSISTENT]) {
             $this->dbh = @oci_pconnect($username, $password, $dsn, $charset, $sessionMode);
         } else {
             $this->dbh = @oci_connect($username, $password, $dsn, $charset, $sessionMode);


### PR DESCRIPTION
When PDO::ATTR_PERSISTENT is configured in the database.php file, the connections are always persistent, because the key exists in the config file (even if is setted false), ignoring DB_PERSISTENT variable in .env.

<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you read the [Contributing Guidelines](https://github.com/yajra/pdo-via-oci8/blob/master/.github/CONTRIBUTING.md)?

If you answered yes, thanks for the PR and we'll get to it ASAP! :)

-->
