### PR TITLE
Added support for oci_set_call_timeout function for v3 (PHP 8 support)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 - Fix #82
 - Move tests to github actions.
 
+## v2.2.0 - 2020-12-11
+
+- Added support for oci_set_call_timeout function [#85](https://github.com/yajra/pdo-via-oci8/pull/85), credits to @ognjenVlad.
+- Fix [yajra/laravel-oci8#621](https://github.com/yajra/laravel-oci8/issues/621).
+
 ## v2.1.3 - 2020-10-20
 
 - Return ora code on failed connection. [#78](https://github.com/yajra/pdo-via-oci8/pull/78), credits to @bendzaminas.

--- a/src/Pdo/Oci8.php
+++ b/src/Pdo/Oci8.php
@@ -525,6 +525,21 @@ class Oci8 extends PDO
     }
 
     /**
+     * Sets a timeout limiting the maximum time a database round-trip
+     *
+     * @param int $time_out
+     * @return bool
+     */
+    public function setCallTimeout($time_out)
+    {
+        if (!$this->dbh) {
+            return false;
+        }
+
+        return oci_set_call_timeout($this->dbh, $time_out);
+    }
+
+    /**
      * Special non PDO function
      * Allocates new collection object.
      *


### PR DESCRIPTION
We would like to see support for oci_set_call_timeout in v3 release which is for PHP 8.

Thanks! :)

