### PR TITLE
[2.x] Add method to set client identifier.

### DIFF
--- a/src/Pdo/Oci8.php
+++ b/src/Pdo/Oci8.php
@@ -495,6 +495,21 @@ class Oci8 extends PDO
     }
 
     /**
+     * Set the client identifier.
+     *
+     * @param $identifier
+     * @return bool
+     */
+    public function setClientIdentifier($identifier)
+    {
+        if (! $this->dbh) {
+            return false;
+        }
+
+        return oci_set_client_identifier($this->dbh, $identifier);
+    }
+
+    /**
      * Configure proper charset.
      *
      * @param array $options

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -207,4 +207,22 @@ class ConnectionTest extends TestCase
         $this->assertTrue($stmt->bindParam(':person', $var, PDO::PARAM_STR));
         $this->assertTrue($stmt->bindParam(':email', $email, PDO::PARAM_STR));
     }
+
+    public function testSetConnectionIdentifier()
+    {
+        $expectedIdentifier = "PDO_OCI8_CON";
+
+        $user = getenv('OCI_USER') ?: self::DEFAULT_USER;
+        $pwd = getenv('OCI_PWD') ?: self::DEFAULT_PWD;
+        $dsn = getenv('OCI_DSN') ?: self::DEFAULT_DSN;
+        $con = new Oci8($dsn, $user, $pwd);
+        $this->assertNotNull($con);
+
+        $con->setClientIdentifier($expectedIdentifier);
+        $stmt = $con->query("SELECT SYS_CONTEXT('USERENV','CLIENT_IDENTIFIER') as IDENTIFIER FROM DUAL");
+        $foundClientIdentifier = $stmt->fetchColumn(0);
+        $con->close();
+
+        $this->assertEquals($expectedIdentifier, $foundClientIdentifier);
+    }
 }


### PR DESCRIPTION
Fix https://github.com/yajra/laravel-oci8/issues/453
Another for fix for #99 

#### Usage

```php
$con = new Oci8($dsn, $user, $pwd);
$con->setClientIdentifier('my-identifier');
```