### PR TITLE
[3.x] Fix Warning reset(): Calling reset() on an object is deprecated

### DIFF
--- a/src/Pdo/Oci8/Statement.php
+++ b/src/Pdo/Oci8/Statement.php
@@ -657,8 +657,10 @@ class Statement extends PDOStatement
 
         $this->results = [];
         while ($row = $this->fetch()) {
-            if ((is_array($row) || is_object($row)) && is_resource(reset($row))) {
-                $stmt = new self(reset($row), $this->connection, $this->options);
+            $mangledObj = get_mangled_object_vars($row);
+
+            if ((is_array($row) || is_object($row)) && is_resource(reset($mangledObj))) {
+                $stmt = new self(reset($mangledObj), $this->connection, $this->options);
                 $stmt->execute();
                 $stmt->setFetchMode($mode, $args);
                 while ($rs = $stmt->fetch()) {


### PR DESCRIPTION
Fix https://github.com/yajra/laravel-oci8/issues/692
Fix https://github.com/yajra/laravel-oci8/issues/692
