### PR TITLE
fix: return object collection instead of oci8 statement resource

### DIFF
--- a/src/Pdo/Oci8/Statement.php
+++ b/src/Pdo/Oci8/Statement.php
@@ -687,7 +687,7 @@ class Statement extends PDOStatement
 
         $this->results = [];
         while ($row = $this->fetch()) {
-            if ((is_array($row) || is_iterable($row)) && is_resource(reset($row))) {
+            if ((is_array($row) || is_object($row)) && is_resource(reset($row))) {
                 $stmt = new self(reset($row), $this->connection, $this->options);
                 $stmt->execute();
                 $stmt->setFetchMode($mode, $args);


### PR DESCRIPTION
This fixes the issue yajra/pdo-via-oci8#106

Apparantly the underlying class does not implement the traversable interface yet