### PR TITLE
fix: Don't suppress exceptions when connecting

### DIFF
--- a/src/Pdo/Oci8.php
+++ b/src/Pdo/Oci8.php
@@ -137,14 +137,21 @@ class Oci8 extends PDO
     {
         $sessionMode = array_key_exists('session_mode', $options) ? $options['session_mode'] : OCI_DEFAULT;
 
-        if (array_key_exists(PDO::ATTR_PERSISTENT, $options) && $options[PDO::ATTR_PERSISTENT]) {
-            $this->dbh = @oci_pconnect($username, $password, $dsn, $charset, $sessionMode);
-        } else {
-            $this->dbh = @oci_connect($username, $password, $dsn, $charset, $sessionMode);
+        try {
+            if (array_key_exists(PDO::ATTR_PERSISTENT, $options) && $options[PDO::ATTR_PERSISTENT]) {
+                $this->dbh = oci_pconnect($username, $password, $dsn, $charset, $sessionMode);
+            } else {
+                $this->dbh = oci_connect($username, $password, $dsn, $charset, $sessionMode);
+            }
+
+            if (! $this->dbh) {
+                $e = oci_error();
+            }
+        } catch (\Throwable $t) {
+            $e = ['code' => $t->getCode(), 'message' => $t->getMessage()];
         }
 
-        if (! $this->dbh) {
-            $e = oci_error();
+        if (isset($e)) {
             throw new Oci8Exception($e['message'], $e['code']);
         }
     }


### PR DESCRIPTION
Related to https://github.com/yajra/laravel-oci8/issues/662

This ensures that the correct exception is delegated to the user, as `oci_error()` will return `FALSE` on system related exceptions.

<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you read the [Contributing Guidelines](https://github.com/yajra/pdo-via-oci8/blob/master/.github/CONTRIBUTING.md)?

If you answered yes, thanks for the PR and we'll get to it ASAP! :)

-->
