### PR TITLE
feat: Added SQLT_BOL to bind type

### DIFF
--- a/src/Pdo/Oci8/Statement.php
+++ b/src/Pdo/Oci8/Statement.php
@@ -348,6 +348,10 @@ class Statement extends PDOStatement
                 $this->blobObjects[$parameter] = &$variable;
                 break;
 
+            case SQLT_BOL:
+                $ociType = SQLT_BOL;
+                break;
+
             default:
                 $ociType = SQLT_CHR;
                 break;


### PR DESCRIPTION
fix #127 

Fixed to accept SQLT_BOL.

## Usage

```
$bindings = [
    'p1' => [
        'value' => true,
        'type' => SQLT_BOL,
    ],
];

$result = DB::connection()->executeFunction('FUNC', $bindings);
```
