### PR TITLE
fix: OCICollection class name reference to match PHP 8 naming convention

### DIFF
--- a/src/Pdo/Oci8/Statement.php
+++ b/src/Pdo/Oci8/Statement.php
@@ -323,7 +323,7 @@ class Statement extends PDOStatement
                 $schema = $options['schema'] ?? '';
                 $type_name = $options['type_name'] ?? '';
 
-                if (strtoupper(get_class($variable)) == 'OCI-COLLECTION') {
+                if (strtoupper(get_class($variable)) == 'OCICOLLECTION') {
                     $collection_temp = $this->connection->getNewCollection($type_name, $schema);
                     $collection_temp->assign($variable);
 


### PR DESCRIPTION
This PR addresses issue #133 

<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you read the [Contributing Guidelines](https://github.com/yajra/pdo-via-oci8/blob/master/.github/CONTRIBUTING.md)?

If you answered yes, thanks for the PR and we'll get to it ASAP! :)

-->
