### PR TITLE
Add a options to fix ignore "expire within" error

### DIFF
--- a/src/Pdo/Oci8.php
+++ b/src/Pdo/Oci8.php
@@ -150,7 +150,7 @@ class Oci8 extends PDO
 
             $flag = true;
 
-            foreach ($ignoreMessageList in $str)
+            foreach ($ignoreMessageList as $str)
             {
                 if (str_contains($e['message'], $str)) {
                     $flag = false;

--- a/src/Pdo/Oci8.php
+++ b/src/Pdo/Oci8.php
@@ -146,7 +146,18 @@ class Oci8 extends PDO
         if (! $this->dbh) {
             $e = oci_error();
 
-            if (! str_contains($e['message'], 'the password will expire within')) {
+            $ignoreMessageList = array_key_exists('ignore_error_messages', $options) ? $options['ignore_error_messages'] : ['the password will expire within'];
+
+            $flag = true;
+
+            foreach ($ignoreMessageList in $str)
+            {
+                if (str_contains($e['message'], $str)) {
+                    $flag = false;
+                }
+            }
+
+            if ($flag) {
                 throw new Oci8Exception($e['message'], $e['code']);
             }
         }


### PR DESCRIPTION
This PR is want to be fix about this:

![save](https://github.com/user-attachments/assets/0f80ce95-2280-40a2-8411-b3682120d4f0)

This error is the same as "the password will expire within" but not ignore. So I write this to let different country use different localized oracle databases can ignore as same as the English version.