### PR TITLE
fix: Silence PHP8.4's deprecation warnings.

### DIFF
--- a/src/Pdo/Oci8.php
+++ b/src/Pdo/Oci8.php
@@ -368,7 +368,7 @@ class Oci8 extends PDO
      *
      * @throws \ReflectionException
      */
-    public function lastInsertId(string $name = null): false|string
+    public function lastInsertId(?string $name = null): false|string
     {
         if (! isset($this->table)) {
             return 0;

--- a/src/Pdo/Oci8/Statement.php
+++ b/src/Pdo/Oci8/Statement.php
@@ -149,6 +149,7 @@ class Statement extends PDOStatement
      * @param  ?string  ...$params  <p> Constructor arguments. </p>
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
+    #[\ReturnTypeWillChange]
     public function setFetchMode($mode, $className = null, ...$params): bool
     {
         $modeArg = $params;

--- a/src/Pdo/Oci8/Statement.php
+++ b/src/Pdo/Oci8/Statement.php
@@ -270,7 +270,7 @@ class Statement extends PDOStatement
         int|string $parameter,
         mixed &$variable,
         int $dataType = PDO::PARAM_STR,
-        int $maxLength = null,
+        ?int $maxLength = null,
         mixed $options = null
     ): bool {
         // strip INOUT type for oci
@@ -387,7 +387,7 @@ class Statement extends PDOStatement
         int|string $parameter,
         array &$variable,
         int $maxTableLength,
-        int $maxItemLength = null,
+        ?int $maxItemLength = null,
         int $type = SQLT_CHR
     ): bool {
         $this->bindings[] = $variable;
@@ -755,7 +755,7 @@ class Statement extends PDOStatement
      *                                   there are bound parameters in the SQL statement being executed.
      * @return bool TRUE on success or FALSE on failure
      */
-    public function execute(array $inputParams = null): bool
+    public function execute(?array $inputParams = null): bool
     {
         $mode = OCI_COMMIT_ON_SUCCESS;
         if ($this->connection->inTransaction() || count($this->blobObjects) > 0) {
@@ -830,7 +830,7 @@ class Statement extends PDOStatement
      *
      * @throws \ReflectionException
      */
-    public function fetchObject(string $className = null, ?array $ctorArgs = []): false|object
+    public function fetchObject(?string $className = null, ?array $ctorArgs = []): false|object
     {
         $this->setFetchMode(PDO::FETCH_CLASS, $className, $ctorArgs);
 


### PR DESCRIPTION
1. Adds a `?` to fix the implicitly nullable parameter declaration warnings.
2. `PDOStatement::setFetchMode` now returns `true`. Not `bool`. [See here](https://github.com/php/php-src/blob/PHP-8.4/ext/pdo/pdo_stmt.stub.php#L65). Here's a [link](https://github.com/php/php-src/commit/b06c95b6310b07ad4770648d0fb05244930a7092#diff-043fe7217766f734dc686afbc82973dcc77bb2484fdd7fc23cf5d55e4737d012L1-R85) to the commit. Not sure why it's not documented. I added `#[\ReturnTypeWillChange]` instead of changing the return type since this would PHP break versions prior to 8.2. 

