### PR TITLE
workaround the OCI_SUCCESS_WITH_INFO error

### DIFF
--- a/src/Pdo/Oci8.php
+++ b/src/Pdo/Oci8.php
@@ -158,6 +158,8 @@ class Oci8 extends PDO
                         throw $e;
                     }
                 }
+            } else {
+                throw $e;
             }
         }
 

--- a/src/Pdo/Oci8.php
+++ b/src/Pdo/Oci8.php
@@ -137,14 +137,25 @@ class Oci8 extends PDO
     {
         $sessionMode = array_key_exists('session_mode', $options) ? $options['session_mode'] : OCI_DEFAULT;
         $cached = array_key_exists('cached', $options) ? $options['cached'] : true;
-
-        if (array_key_exists(PDO::ATTR_PERSISTENT, $options) && $options[PDO::ATTR_PERSISTENT]) {
-            $this->dbh = oci_pconnect($username, $password, $dsn, $charset, $sessionMode);
-        } else {
-            if ($cached) {
-                $this->dbh = oci_connect($username, $password, $dsn, $charset, $sessionMode);
+        try {
+            if (array_key_exists(PDO::ATTR_PERSISTENT, $options) && $options[PDO::ATTR_PERSISTENT]) {
+                $this->dbh = oci_pconnect($username, $password, $dsn, $charset, $sessionMode);
             } else {
-                $this->dbh = oci_new_connect($username, $password, $dsn, $charset, $sessionMode);
+                if ($cached) {
+                    $this->dbh = oci_connect($username, $password, $dsn, $charset, $sessionMode);
+                } else {
+                    $this->dbh = oci_new_connect($username, $password, $dsn, $charset, $sessionMode);
+                }
+            }
+        } catch (Exception $e) {
+            if (array_key_exists(PDO::ATTR_PERSISTENT, $options) && $options[PDO::ATTR_PERSISTENT]) {
+                $this->dbh = oci_pconnect($username, $password, $dsn, $charset, $sessionMode);
+            } else {
+                if ($cached) {
+                    $this->dbh = oci_connect($username, $password, $dsn, $charset, $sessionMode);
+                } else {
+                    throw $e;
+                }
             }
         }
 

--- a/src/Pdo/Oci8.php
+++ b/src/Pdo/Oci8.php
@@ -152,11 +152,7 @@ class Oci8 extends PDO
                 if (array_key_exists(PDO::ATTR_PERSISTENT, $options) && $options[PDO::ATTR_PERSISTENT]) {
                     $this->dbh = oci_pconnect($username, $password, $dsn, $charset, $sessionMode);
                 } else {
-                    if ($cached) {
-                        $this->dbh = oci_connect($username, $password, $dsn, $charset, $sessionMode);
-                    } else {
-                        throw $e;
-                    }
+                    throw $e;
                 }
             } else {
                 throw $e;

--- a/src/Pdo/Oci8.php
+++ b/src/Pdo/Oci8.php
@@ -148,13 +148,15 @@ class Oci8 extends PDO
                 }
             }
         } catch (Exception $e) {
-            if (array_key_exists(PDO::ATTR_PERSISTENT, $options) && $options[PDO::ATTR_PERSISTENT]) {
-                $this->dbh = oci_pconnect($username, $password, $dsn, $charset, $sessionMode);
-            } else {
-                if ($cached) {
-                    $this->dbh = oci_connect($username, $password, $dsn, $charset, $sessionMode);
+            if (! oci_error()) {
+                if (array_key_exists(PDO::ATTR_PERSISTENT, $options) && $options[PDO::ATTR_PERSISTENT]) {
+                    $this->dbh = oci_pconnect($username, $password, $dsn, $charset, $sessionMode);
                 } else {
-                    throw $e;
+                    if ($cached) {
+                        $this->dbh = oci_connect($username, $password, $dsn, $charset, $sessionMode);
+                    } else {
+                        throw $e;
+                    }
                 }
             }
         }


### PR DESCRIPTION
When I encountered this error, I accidentally realized that use the oci_pconnect and oci_connect again to workaround the problem. but the oci_new_connect cannot workaround. So I wrote the workaround code.

This may cause by the extensions problem. But I don't have time to fix it.

It seems that in PHP 8.1.17 with oci8 3.2.1 will got this problem. So I try this to workaround the problem. 

