### PR TITLE
ci: update workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,52 +18,100 @@ jobs:
 
     services:
       oracle:
-        image: deepdiver/docker-oracle-xe-11g:2.0
+        image: >-
+          ${{ matrix.oracle == '11g' && 'deepdiver/docker-oracle-xe-11g:2.0' ||
+          matrix.oracle == '19c' &&
+          'container-registry.oracle.com/database/adb-free:25.10.2.1' ||
+          matrix.oracle == '21c' &&
+          'container-registry.oracle.com/database/express:21.3.0-xe' ||
+          matrix.oracle == '23ai' &&
+          'container-registry.oracle.com/database/adb-free:25.9.3.2-23ai-amd64' ||
+          matrix.oracle == '26ai' &&
+          'container-registry.oracle.com/database/free:23.26.1.0' }}
         ports:
-          - 49160:22
           - 1521:1521
+        env:
+          ORACLE_PWD: ${{ (matrix.oracle == '11g' || matrix.oracle == '21c' || matrix.oracle == '26ai') && 'oracle' || '' }}
+          ADMIN_PASSWORD: ${{ (matrix.oracle == '19c' || matrix.oracle == '23ai') && 'SecureDb1234' || '' }}
+          WALLET_PASSWORD: ${{ (matrix.oracle == '19c' || matrix.oracle == '23ai') && 'DummyWallet123' || '' }}
+        options: >-
+          --health-cmd="bash -lc 'echo > /dev/tcp/127.0.0.1/1521'"
+          --health-interval=30s
+          --health-timeout=10s
+          --health-retries=20
+          --health-start-period=20m
 
     strategy:
       fail-fast: true
       matrix:
         php: [8.0, 8.1, 8.2, 8.3, 8.4, 8.5]
         stability: [prefer-stable]
+        oracle: [11g, 19c, 21c, 23ai, 26ai]
 
-    name: PHP ${{ matrix.php }} - STABILITY ${{ matrix.stability }}
-
-    env:
-        key: ${{ matrix.php }}-v1
-        extensions: oci8
+    name: PHP ${{ matrix.php }} - ORACLE ${{ matrix.oracle }} - STABILITY ${{ matrix.stability }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup cache environment
-        id: extcache
-        uses: shivammathur/cache-extensions@v1
-        with:
-            php-version: ${{ matrix.php }}
-            extensions: ${{ env.extensions }}
-            key: ${{ env.key }}
-
-      - name: Cache extensions
-        uses: actions/cache@v4
-        with:
-            path: ${{ steps.extcache.outputs.dir }}
-            key: ${{ steps.extcache.outputs.key }}
-            restore-keys: ${{ steps.extcache.outputs.key }}
+        uses: actions/checkout@v7
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: ${{ env.extensions }}
+          extensions: oci8
           tools: composer:v2
           coverage: none
 
       - name: Install Project Dependencies
         run: composer install -q --no-interaction --no-progress
 
+      - name: Wait for Oracle
+        timeout-minutes: 16
+        run: |
+          if [ "${{ matrix.oracle }}" = "11g" ]; then
+            SQLPLUS_PATH="/u01/app/oracle/product/11.2.0/xe/bin/sqlplus -L"
+            ORACLE_ENV="export ORACLE_HOME=/u01/app/oracle/product/11.2.0/xe; export PATH=\$ORACLE_HOME/bin:\$PATH; export LD_LIBRARY_PATH=\$ORACLE_HOME/lib:\$LD_LIBRARY_PATH;"
+            LOGIN="system/oracle@XE"
+          elif [ "${{ matrix.oracle }}" = "21c" ]; then
+            SQLPLUS_PATH="sqlplus -L"
+            ORACLE_ENV=""
+            LOGIN="system/oracle@XEPDB1"
+          elif [ "${{ matrix.oracle }}" = "26ai" ]; then
+            SQLPLUS_PATH="sqlplus -L"
+            ORACLE_ENV=""
+            LOGIN="system/oracle@FREEPDB1"
+          else
+            SQLPLUS_PATH="sqlplus -L"
+            ORACLE_ENV="export TNS_ADMIN=/u01/app/oracle/wallets/tls_wallet;"
+            LOGIN="admin/SecureDb1234@myatp_low"
+          fi
+
+          WAIT_CMD="$ORACLE_ENV echo 'select 1 from dual;' | $SQLPLUS_PATH -s $LOGIN"
+          DEADLINE=$((SECONDS + 900))
+          ATTEMPT=0
+
+          while [ "$SECONDS" -lt "$DEADLINE" ]; do
+            ATTEMPT=$((ATTEMPT + 1))
+            echo "Checking Oracle with SQLPlus (attempt $ATTEMPT)..."
+            if timeout 20s docker exec -u oracle "${{ job.services.oracle.id }}" bash -lc "$WAIT_CMD" >/dev/null 2>&1; then
+              echo "Oracle is SQLPlus-ready."
+              exit 0
+            fi
+            sleep 10
+          done
+
+          echo "Oracle did not become SQLPlus-ready within 15 minutes."
+          docker logs --tail 200 "${{ job.services.oracle.id }}"
+          exit 1
+
       - name: Run Tests
+        env:
+          OCI_USER: ${{ (matrix.oracle == '19c' || matrix.oracle == '23ai') && 'admin' || 'system' }}
+          OCI_PWD: ${{ (matrix.oracle == '19c' || matrix.oracle == '23ai') && 'SecureDb1234' || 'oracle' }}
+          OCI_DSN: >-
+            ${{ matrix.oracle == '11g' && 'oci:dbname=127.0.0.1:1521/XE' ||
+            matrix.oracle == '19c' && 'oci:dbname=127.0.0.1:1521/MYATP_low.adb.oraclecloud.com' ||
+            matrix.oracle == '21c' && 'oci:dbname=127.0.0.1:1521/XEPDB1' ||
+            matrix.oracle == '23ai' && 'oci:dbname=127.0.0.1:1521/MYATP_low.adb.oraclecloud.com' ||
+            matrix.oracle == '26ai' && 'oci:dbname=127.0.0.1:1521/FREEPDB1' }}
         run: vendor/bin/phpunit


### PR DESCRIPTION
- Expand the CI matrix to test PHP 8.0–8.5 against Oracle 19c, 21c, 23ai, and 26ai too.
- Configure the appropriate container image, credentials, and DSN for each Oracle version.
- Add health checks and SQLPlus readiness polling before running PHPUnit.
- Update actions/checkout and simplify OCI8 setup by removing the separate extension cache.

Thank you for reviewing!